### PR TITLE
Fix project not initializing correctly when loaded from an URL

### DIFF
--- a/src/js/controllers/controllers.js
+++ b/src/js/controllers/controllers.js
@@ -157,8 +157,7 @@ angular.module('palladio.controllers', ['palladio.services', 'palladio'])
 			$http.get(path)
 				.success(function(data) {
 					$scope.loadError = null;
-					loadService.loadJson(data);
-					$scope.onLoad();
+					loadService.loadJson(data).then($scope.onLoad);
 				})
 				.error(function() {
 					spinnerService.hide();


### PR DESCRIPTION
Issue #117 . The problem occurred because loadService.loadJson returns a promise, but onLoad was not chained to that promise. Therefore, onLoad ran before all information it needed was available.